### PR TITLE
Exporting and renaming the function to return the most specific type

### DIFF
--- a/mapper/types.go
+++ b/mapper/types.go
@@ -46,7 +46,7 @@ func isDescendent(descendent, ancestor string) bool {
 
 // MostSpecific returns the most specific from a list of types in an hierarchy
 // behaviour is undefined if any of the types are siblings.
-func mostSpecific(types []string) (string, error) {
+func MostSpecificType(types []string) (string, error) {
 	if len(types) == 0 {
 		return "", errors.New("no types supplied")
 	}

--- a/mapper/uri_utils.go
+++ b/mapper/uri_utils.go
@@ -42,7 +42,7 @@ func APIURL(uuid string, labels []string, env string) string {
 	}
 
 	path := ""
-	mostSpecific, err := mostSpecific(labels)
+	mostSpecific, err := MostSpecificType(labels)
 	if err == nil {
 		for t := mostSpecific; t != "" && path == ""; t = ParentType(t) {
 			path = apiPaths[t]

--- a/mapper/uri_utils_test.go
+++ b/mapper/uri_utils_test.go
@@ -209,7 +209,7 @@ func TestMostSpecific(t *testing.T) {
 			ErrNotHierarchy,
 		},
 	} {
-		ms, err := mostSpecific(t.input)
+		ms, err := MostSpecificType(t.input)
 		assert.Equal(t.expected, ms)
 		assert.Equal(t.err, err)
 	}


### PR DESCRIPTION
Given a list of node labels it will return the most specific type - This functionality is useful in the concepts-rw-neo4j app therefore I am exporting and renaming it. This is not a breaking change